### PR TITLE
Simplify importing with 2018 features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target/
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
+[workspace]
+members = ["impl"]
+
 [package]
 name = "glsl-to-spirv-macros"
 version = "0.1.2-pre"
 authors = ["Dylan Ede <dylanede@googlemail.com>"]
 description = """
 Macros for generating SPIR-V shader binaries from GLSL at compile time for use with Vulkan.
-
-To use this crate, you must also use the glsl-to-spirv-macros-impl crate.
-\
 """
 documentation = "https://docs.rs/glsl-to-spirv-macros"
 repository = "https://github.com/dylanede/glsl-to-spirv-macros"
@@ -14,6 +14,10 @@ readme = "README.md"
 license = "MIT / Apache-2.0"
 keywords = ["vulkan", "spirv", "glsl", "shader", "macro"]
 exclude = ["impl/**/*"]
+edition = "2018"
+
+[dependencies]
+glsl-to-spirv-macros-impl = { path = "impl" }
 
 [package.metadata.release]
 pre-release-commit-message = "Release {{version}} 🎉🎉"

--- a/README.md
+++ b/README.md
@@ -5,25 +5,18 @@
 ```toml
 [dependencies]
 glsl-to-spirv-macros = "0.1.1"
-glsl-to-spirv-macros-impl = "0.1.0"
 ```
 
 Rust macros for generating SPIR-V binaries at compile time for use with Vulkan.
-
-To use this crate, you must also use the glsl-to-spirv-macros-impl crate.
 
 ### [Documentation](https://docs.rs/glsl-to-spirv-macros)
 
 Use this crate to compile your GLSL shaders at compile time into binaries embedded in your program.
 
-This crate requires you to also use the `glsl-to-spirv-macros-impl` crate. Without it these macros will not work.
-Unfortunately it is not yet possible to combine the two crates into one.
-
 Example usage:
 
 ```rust
-#[macro_use] extern crate glsl_to_spirv_macros;
-#[macro_use] extern crate glsl_to_spirv_macros_impl;
+use glsl_to_spirv_macros::{glsl_vs, include_glsl_fs};
 
 static some_shader: &'static [u8] = glsl_vs!{r#"
     // Shader code here

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/dylanede/glsl-to-spirv-macros"
 readme = "../README.md"
 license = "MIT / Apache-2.0"
 keywords = ["vulkan", "spirv", "glsl", "shader", "macro"]
+edition = "2018"
 
 [lib]
 proc-macro = true

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -32,7 +32,9 @@ macro_rules! glsl {
 #[proc_macro_derive(GLSLEmbedImpl, attributes(src, path, ty))]
 pub fn macro_impl(input: TokenStream) -> TokenStream {
     let source = input.to_string();
-    let ast = syn::parse_macro_input(&source).ok().expect("Invalid shader macro arguments - you must specify a single string literal.");
+    let ast = syn::parse_macro_input(&source)
+        .ok()
+        .expect("Invalid shader macro arguments - you must specify a single string literal.");
     let mut source_string = None;
     let mut path_string = None;
     let mut ty_string = None;
@@ -50,9 +52,11 @@ pub fn macro_impl(input: TokenStream) -> TokenStream {
                 }
             }
             syn::MetaItem::List(ref ident, _) if ident == "allow" => {}
-            _ => panic!("Invalid shader macro arguments - you must specify a single string literal.")
+            _ => {
+                panic!("Invalid shader macro arguments - you must specify a single string literal.")
+            }
         }
-    };
+    }
     let source_string = if let Some(source_string) = source_string {
         source_string
     } else {
@@ -72,7 +76,7 @@ pub fn macro_impl(input: TokenStream) -> TokenStream {
         "tcs" => glsl_to_spirv::ShaderType::TessellationControl,
         "tes" => glsl_to_spirv::ShaderType::TessellationEvaluation,
         "cs" => glsl_to_spirv::ShaderType::Compute,
-        _ => panic!()
+        _ => panic!(),
     };
     let mut spirv_file: File = match glsl_to_spirv::compile(&source_string, ty) {
         Ok(compiled) => compiled,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,7 @@
 //! Example usage:
 //!
 //! ```ignore
-//! #[macro_use] extern crate glsl_to_spirv_macros;
-//! #[macro_use] extern crate glsl_to_spirv_macros_impl;
+//! use glsl_to_spirv_macros::{glsl_vs, include_glsl_fs};
 //!
 //! static some_shader: &'static [u8] = glsl_vs!{r#"
 //!     // Shader code here
@@ -24,14 +23,16 @@
 //! These macros generate Vulkan-compatible SPIR-V binaries using the official glslang compiler - they
 //! are not designed for use with other APIs, like OpenCL.
 
+pub use glsl_to_spirv_macros_impl::*;
+
 /// Compiles a string containing a GLSL vertex shader into SPIR-V binary data.
 #[macro_export]
 macro_rules! glsl_vs {
     ($source:tt) => {{
         #[allow(dead_code)]
-        #[derive(GLSLEmbedImpl)]
+        #[derive($crate::GLSLEmbedImpl)]
         #[src=$source]
-        #[ty="vs"]
+        #[ty = "vs"]
         struct Dummy;
         &DATA as &'static [u8]
     }};
@@ -42,9 +43,9 @@ macro_rules! glsl_vs {
 macro_rules! glsl_fs {
     ($source:tt) => {{
         #[allow(dead_code)]
-        #[derive(GLSLEmbedImpl)]
+        #[derive($crate::GLSLEmbedImpl)]
         #[src=$source]
-        #[ty="fs"]
+        #[ty = "fs"]
         struct Dummy;
         &DATA as &'static [u8]
     }};
@@ -55,9 +56,9 @@ macro_rules! glsl_fs {
 macro_rules! glsl_gs {
     ($source:tt) => {{
         #[allow(dead_code)]
-        #[derive(GLSLEmbedImpl)]
+        #[derive($crate::GLSLEmbedImpl)]
         #[src=$source]
-        #[ty="gs"]
+        #[ty = "gs"]
         struct Dummy;
         &DATA as &'static [u8]
     }};
@@ -68,9 +69,9 @@ macro_rules! glsl_gs {
 macro_rules! glsl_tcs {
     ($source:tt) => {{
         #[allow(dead_code)]
-        #[derive(GLSLEmbedImpl)]
+        #[derive($crate::GLSLEmbedImpl)]
         #[src=$source]
-        #[ty="tcs"]
+        #[ty = "tcs"]
         struct Dummy;
         &DATA as &'static [u8]
     }};
@@ -81,9 +82,9 @@ macro_rules! glsl_tcs {
 macro_rules! glsl_tes {
     ($source:tt) => {{
         #[allow(dead_code)]
-        #[derive(GLSLEmbedImpl)]
+        #[derive($crate::GLSLEmbedImpl)]
         #[src=$source]
-        #[ty="tes"]
+        #[ty = "tes"]
         struct Dummy;
         &DATA as &'static [u8]
     }};
@@ -94,9 +95,9 @@ macro_rules! glsl_tes {
 macro_rules! glsl_cs {
     ($source:tt) => {{
         #[allow(dead_code)]
-        #[derive(GLSLEmbedImpl)]
+        #[derive($crate::GLSLEmbedImpl)]
         #[src=$source]
-        #[ty="cs"]
+        #[ty = "cs"]
         struct Dummy;
         &DATA as &'static [u8]
     }};
@@ -107,9 +108,9 @@ macro_rules! glsl_cs {
 macro_rules! include_glsl_vs {
     ($path:tt) => {{
         #[allow(dead_code)]
-        #[derive(GLSLEmbedImpl)]
+        #[derive($crate::GLSLEmbedImpl)]
         #[path=$path]
-        #[ty="vs"]
+        #[ty = "vs"]
         struct Dummy;
         &DATA as &'static [u8]
     }};
@@ -120,9 +121,9 @@ macro_rules! include_glsl_vs {
 macro_rules! include_glsl_fs {
     ($path:tt) => {{
         #[allow(dead_code)]
-        #[derive(GLSLEmbedImpl)]
+        #[derive($crate::GLSLEmbedImpl)]
         #[path=$path]
-        #[ty="fs"]
+        #[ty = "fs"]
         struct Dummy;
         &DATA as &'static [u8]
     }};
@@ -133,9 +134,9 @@ macro_rules! include_glsl_fs {
 macro_rules! include_glsl_gs {
     ($path:tt) => {{
         #[allow(dead_code)]
-        #[derive(GLSLEmbedImpl)]
+        #[derive($crate::GLSLEmbedImpl)]
         #[path=$path]
-        #[ty="gs"]
+        #[ty = "gs"]
         struct Dummy;
         &DATA as &'static [u8]
     }};
@@ -146,9 +147,9 @@ macro_rules! include_glsl_gs {
 macro_rules! include_glsl_tcs {
     ($path:tt) => {{
         #[allow(dead_code)]
-        #[derive(GLSLEmbedImpl)]
+        #[derive($crate::GLSLEmbedImpl)]
         #[path=$path]
-        #[ty="tcs"]
+        #[ty = "tcs"]
         struct Dummy;
         &DATA as &'static [u8]
     }};
@@ -159,9 +160,9 @@ macro_rules! include_glsl_tcs {
 macro_rules! include_glsl_tes {
     ($path:tt) => {{
         #[allow(dead_code)]
-        #[derive(GLSLEmbedImpl)]
+        #[derive($crate::GLSLEmbedImpl)]
         #[path=$path]
-        #[ty="tes"]
+        #[ty = "tes"]
         struct Dummy;
         &DATA as &'static [u8]
     }};
@@ -172,9 +173,9 @@ macro_rules! include_glsl_tes {
 macro_rules! include_glsl_cs {
     ($path:tt) => {{
         #[allow(dead_code)]
-        #[derive(GLSLEmbedImpl)]
+        #[derive($crate::GLSLEmbedImpl)]
         #[path=$path]
-        #[ty="cs"]
+        #[ty = "cs"]
         struct Dummy;
         &DATA as &'static [u8]
     }};


### PR DESCRIPTION
Rust 2018 gives us the tools we need to no longer expose the procmacro
*-impl crate to consumers.